### PR TITLE
Potential Fix For The Playwright E2E Job Being Skipped (Retry)

### DIFF
--- a/.github/workflows/e2e-playwright-allure_report.yml
+++ b/.github/workflows/e2e-playwright-allure_report.yml
@@ -18,6 +18,8 @@ jobs:
   run-playwright-e2e:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    outputs:
+      upload_success: ${{ steps.set-upload-status.outputs.upload_success }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -61,16 +63,26 @@ jobs:
         run: npx playwright test --project=${{ inputs.project || 'chromium_test_workflow' }}
 
       - name: Upload test results
+        id: upload-step
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: playwright-results
           path: playwright-test-results/allure-results
 
+      - name: Set upload success output
+        id: set-upload-status
+        run: |
+          if [ "${{ steps.upload-step.conclusion }}" == "success" ]; then
+            echo "upload_success=true" >> $GITHUB_OUTPUT
+          else
+            echo "upload_success=false" >> $GITHUB_OUTPUT
+          fi
+
   publish-results:
     needs: run-playwright-e2e
     runs-on: ubuntu-latest
-    if: "${{ github.repository_owner == 'DependencyTrack' }}"
+    if: "${{ needs.tests.outputs.upload_success == 'true' && github.repository_owner == 'DependencyTrack' }}"
     steps:
       - name: Download test results
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-playwright-allure_report.yml
+++ b/.github/workflows/e2e-playwright-allure_report.yml
@@ -82,7 +82,7 @@ jobs:
   publish-results:
     needs: run-playwright-e2e
     runs-on: ubuntu-latest
-    if: "${{ needs.tests.outputs.upload_success == 'true' && github.repository_owner == 'DependencyTrack' }}"
+    if: "${{ needs.run-playwright-e2e.outputs.upload_success == 'true' && github.repository_owner == 'DependencyTrack' }}"
     steps:
       - name: Download test results
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### Description

This approach should fix the execution of the second job and will only be executed if the **Upload test results** Step successfully uploaded the test results, in order for the github-page not being generated on missing data

### Addressed Issue

Fixes the second job in .github/workflows/e2e-playwright-allure_report.yml to execute 

### Additional Details


### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
